### PR TITLE
update ganache-cli v6.8.0 istanbul.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/paxosglobal/pax-contracts#readme",
   "dependencies": {},
   "devDependencies": {
-    "ganache-cli": "^6.1.2",
+    "ganache-cli": "^6.8.0",
     "solc": "^0.4.24",
     "solidity-coverage": "^0.5.4",
     "solium": "^1.1.8",


### PR DESCRIPTION
Ganache-cli upgrade istabul

## 
https://github.com/trufflesuite/ganache-cli/releases/tag/v6.8.0-istanbul.0