### PR TITLE
Enhance signature validation patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ to the proxy contract.
 
 The proxy contract and implementation contracts are verified on etherscan at the following links:
 - Proxy: https://etherscan.io/token/0x8e870d67f660d95d5be530380d0ec0bd388289e1
-- Implementation: https://etherscan.io/token/0x28eDAB7eEC878d54fa877fFFf4604DFD649F533F
+- Implementation: https://etherscan.io/token/0xf459Ff5EC7d1F371CB34754BDA5FE5FCE2c9054d
 
 The SupplyControl contract and implementation contracts are verified on etherscan at the following links:
 - Proxy: https://etherscan.io/address/0xDc55B5F0f2d441C1116DcC3b9D56314Da7f5496D


### PR DESCRIPTION
The USDP implementation has been updated to [0xf459Ff5EC7d1F371CB34754BDA5FE5FCE2c9054d](https://etherscan.io/address/0xf459ff5ec7d1f371cb34754bda5fe5fce2c9054d)

This change adds byte array signature support for:

- transferWithAuthorization
- transferWithAuthorizationBatch
- receiveWithAuthorization
- cancelBatch
- permit (EIP-2612)

This enables tokens to handle smart contract wallet [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) signature validation for all functions which previously only took ECDSA signatures. This is done by using SignatureChecker.isValidSignatureNow() instead of EIP712._recover().

Additionally this PR recomputes DOMAIN_SEPARATOR on the fly instead of caching it to handle chain forks.

Details are available in this PR: https://github.com/paxosglobal/paxos-token-contracts/pull/14